### PR TITLE
Add trimming for ip address in lookup endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlas-rs"
-version = "0.0.5"
-edition = "2021"
+version = "0.0.6"
+edition = "2026"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/services/lookup.rs
+++ b/src/services/lookup.rs
@@ -55,6 +55,7 @@ async fn handle(data: web::Data<MaxmindDB>, path: web::Path<(String, String)>) -
 
     let ip_addresses: Vec<IpAddr> = match ip_addresses
         .split(',')
+        .map(str::trim)
         .map(|ip_address| {
             ip_address.parse().map_err(|_| {
                 bad_request(


### PR DESCRIPTION
I've also bumped version to `0.0.6` 